### PR TITLE
Remove CNAME

### DIFF
--- a/1.3.4/architecture.html
+++ b/1.3.4/architecture.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/cli.html
+++ b/1.3.4/cli.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/environment_config.html
+++ b/1.3.4/environment_config.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/faq.html
+++ b/1.3.4/faq.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/get_started.html
+++ b/1.3.4/get_started.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>
@@ -68,7 +68,7 @@
 
 <h2 id="install">Install</h2>
 
-<p>This tutorial assumes that you have installed Sceptre. Instructions on how to do this are found in the section on <a href="https://sceptre.cloudreach.com./docs/install.html">installation</a>.</p>
+<p>This tutorial assumes that you have installed Sceptre. Instructions on how to do this are found in the section on <a href="https://sceptre.github.io./docs/install.html">installation</a>.</p>
 
 <h2 id="directory-structure">Directory Structure</h2>
 
@@ -191,7 +191,7 @@ $ touch config/dev/config.yaml config/dev/vpc.yaml templates/vpc.json
 
 <h2 id="next-steps">Next Steps</h2>
 
-<p>Further details can be found in the full <a href="https://sceptre.cloudreach.com./docs">documentation</a>.</p>
+<p>Further details can be found in the full <a href="https://sceptre.github.io./docs">documentation</a>.</p>
 
     </div>
   </div>

--- a/1.3.4/hooks.html
+++ b/1.3.4/hooks.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/index.html
+++ b/1.3.4/index.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>
@@ -68,7 +68,7 @@
 
 <p>This documentation acts as an in-depth reference for all of Sceptre’s features.</p>
 
-<p>Beginners should consider reading our <a href="https://sceptre.cloudreach.com./docs/get_started.html">getting started guide</a>, which provides a walk-through tutorial.</p>
+<p>Beginners should consider reading our <a href="https://sceptre.github.io./docs/get_started.html">getting started guide</a>, which provides a walk-through tutorial.</p>
 
     </div>
   </div>

--- a/1.3.4/install.html
+++ b/1.3.4/install.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/resolvers.html
+++ b/1.3.4/resolvers.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/stack_config.html
+++ b/1.3.4/stack_config.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/templates.html
+++ b/1.3.4/templates.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.3.4/terminology.html
+++ b/1.3.4/terminology.html
@@ -18,7 +18,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -30,7 +30,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/architecture.html
+++ b/1.4.2/architecture.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/cli.html
+++ b/1.4.2/cli.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/environment_config.html
+++ b/1.4.2/environment_config.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/faq.html
+++ b/1.4.2/faq.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/get_started.html
+++ b/1.4.2/get_started.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>
@@ -72,7 +72,7 @@
 
 <h2 id="install">Install</h2>
 
-<p>This tutorial assumes that you have installed Sceptre. Instructions on how to do this are found in the section on <a href="https://sceptre.cloudreach.com./docs/install.html">installation</a>.</p>
+<p>This tutorial assumes that you have installed Sceptre. Instructions on how to do this are found in the section on <a href="https://sceptre.github.io./docs/install.html">installation</a>.</p>
 
 <h2 id="directory-structure">Directory Structure</h2>
 
@@ -195,7 +195,7 @@ $ touch config/dev/config.yaml config/dev/vpc.yaml templates/vpc.json
 
 <h2 id="next-steps">Next Steps</h2>
 
-<p>Further details can be found in the full <a href="https://sceptre.cloudreach.com./docs">documentation</a>.</p>
+<p>Further details can be found in the full <a href="https://sceptre.github.io./docs">documentation</a>.</p>
 
     </div>
   </div>

--- a/1.4.2/hooks.html
+++ b/1.4.2/hooks.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/index.html
+++ b/1.4.2/index.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>
@@ -72,7 +72,7 @@
 
 <p>This documentation acts as an in-depth reference for all of Sceptre’s features.</p>
 
-<p>Beginners should consider reading our <a href="https://sceptre.cloudreach.com./docs/get_started.html">getting started guide</a>, which provides a walk-through tutorial.</p>
+<p>Beginners should consider reading our <a href="https://sceptre.github.io./docs/get_started.html">getting started guide</a>, which provides a walk-through tutorial.</p>
 
     </div>
   </div>

--- a/1.4.2/install.html
+++ b/1.4.2/install.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/resolvers.html
+++ b/1.4.2/resolvers.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/stack_config.html
+++ b/1.4.2/stack_config.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/templates.html
+++ b/1.4.2/templates.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.4.2/terminology.html
+++ b/1.4.2/terminology.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/architecture.html
+++ b/1.5.0/architecture.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/cli.html
+++ b/1.5.0/cli.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/environment_config.html
+++ b/1.5.0/environment_config.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/faq.html
+++ b/1.5.0/faq.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/get_started.html
+++ b/1.5.0/get_started.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>
@@ -71,7 +71,7 @@
 
 <h2 id="install">Install</h2>
 
-<p>This tutorial assumes that you have installed Sceptre. Instructions on how to do this are found in the section on <a href="https://sceptre.cloudreach.com./docs/install.html">installation</a>.</p>
+<p>This tutorial assumes that you have installed Sceptre. Instructions on how to do this are found in the section on <a href="https://sceptre.github.io./docs/install.html">installation</a>.</p>
 
 <h2 id="directory-structure">Directory Structure</h2>
 
@@ -194,7 +194,7 @@ $ touch config/dev/config.yaml config/dev/vpc.yaml templates/vpc.json
 
 <h2 id="next-steps">Next Steps</h2>
 
-<p>Further details can be found in the full <a href="https://sceptre.cloudreach.com./docs">documentation</a>.</p>
+<p>Further details can be found in the full <a href="https://sceptre.github.io./docs">documentation</a>.</p>
 
     </div>
   </div>

--- a/1.5.0/hooks.html
+++ b/1.5.0/hooks.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/index.html
+++ b/1.5.0/index.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>
@@ -71,7 +71,7 @@
 
 <p>This documentation acts as an in-depth reference for all of Sceptre’s features.</p>
 
-<p>Beginners should consider reading our <a href="https://sceptre.cloudreach.com./docs/get_started.html">getting started guide</a>, which provides a walk-through tutorial.</p>
+<p>Beginners should consider reading our <a href="https://sceptre.github.io./docs/get_started.html">getting started guide</a>, which provides a walk-through tutorial.</p>
 
     </div>
   </div>

--- a/1.5.0/install.html
+++ b/1.5.0/install.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/resolvers.html
+++ b/1.5.0/resolvers.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/stack_config.html
+++ b/1.5.0/stack_config.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/templates.html
+++ b/1.5.0/templates.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/1.5.0/terminology.html
+++ b/1.5.0/terminology.html
@@ -22,7 +22,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="https://sceptre.cloudreach.com/latest/">Sceptre</a>
+      <a class="navbar-brand" href="https://sceptre.github.io/latest/">Sceptre</a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsable-navbar">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
@@ -34,7 +34,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="collapsable-navbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://sceptre.cloudreach.com/latest/">About</a></li>
+        <li><a href="https://sceptre.github.io/latest/">About</a></li>
         <li><a href="https://github.com/cloudreach/sceptre">GitHub</a></li>
       </ul>
     </div>

--- a/2.2.0/_modules/index.html
+++ b/2.2.0/_modules/index.html
@@ -245,7 +245,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre.html
+++ b/2.2.0/_modules/sceptre.html
@@ -185,7 +185,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 <span class="n">__version__</span> <span class="o">=</span> <span class="s1">&#39;2.2.0&#39;</span>
 
 
@@ -244,7 +244,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/cli/helpers.html
+++ b/2.2.0/_modules/sceptre/cli/helpers.html
@@ -567,7 +567,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/config.html
+++ b/2.2.0/_modules/sceptre/config.html
@@ -186,7 +186,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -241,7 +241,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/config/graph.html
+++ b/2.2.0/_modules/sceptre/config/graph.html
@@ -330,7 +330,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/config/reader.html
+++ b/2.2.0/_modules/sceptre/config/reader.html
@@ -729,7 +729,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/config/strategies.html
+++ b/2.2.0/_modules/sceptre/config/strategies.html
@@ -298,7 +298,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/connection_manager.html
+++ b/2.2.0/_modules/sceptre/connection_manager.html
@@ -447,7 +447,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/context.html
+++ b/2.2.0/_modules/sceptre/context.html
@@ -344,7 +344,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/exceptions.html
+++ b/2.2.0/_modules/sceptre/exceptions.html
@@ -385,7 +385,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/helpers.html
+++ b/2.2.0/_modules/sceptre/helpers.html
@@ -334,7 +334,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/hooks.html
+++ b/2.2.0/_modules/sceptre/hooks.html
@@ -333,7 +333,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/hooks/asg_scaling_processes.html
+++ b/2.2.0/_modules/sceptre/hooks/asg_scaling_processes.html
@@ -315,7 +315,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/hooks/cmd.html
+++ b/2.2.0/_modules/sceptre/hooks/cmd.html
@@ -253,7 +253,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/plan.html
+++ b/2.2.0/_modules/sceptre/plan.html
@@ -186,7 +186,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -241,7 +241,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/plan/actions.html
+++ b/2.2.0/_modules/sceptre/plan/actions.html
@@ -1085,7 +1085,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/plan/executor.html
+++ b/2.2.0/_modules/sceptre/plan/executor.html
@@ -289,7 +289,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/plan/plan.html
+++ b/2.2.0/_modules/sceptre/plan/plan.html
@@ -582,7 +582,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/resolvers.html
+++ b/2.2.0/_modules/sceptre/resolvers.html
@@ -348,7 +348,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/resolvers/environment_variable.html
+++ b/2.2.0/_modules/sceptre/resolvers/environment_variable.html
@@ -255,7 +255,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/resolvers/file_contents.html
+++ b/2.2.0/_modules/sceptre/resolvers/file_contents.html
@@ -254,7 +254,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/resolvers/stack_output.html
+++ b/2.2.0/_modules/sceptre/resolvers/stack_output.html
@@ -395,7 +395,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/stack.html
+++ b/2.2.0/_modules/sceptre/stack.html
@@ -503,7 +503,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/stack_status.html
+++ b/2.2.0/_modules/sceptre/stack_status.html
@@ -251,7 +251,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/stack_status_colourer.html
+++ b/2.2.0/_modules/sceptre/stack_status_colourer.html
@@ -289,7 +289,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/_modules/sceptre/template.html
+++ b/2.2.0/_modules/sceptre/template.html
@@ -564,7 +564,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/about.html
+++ b/2.2.0/about.html
@@ -256,7 +256,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/modules.html
+++ b/2.2.0/apidoc/modules.html
@@ -302,7 +302,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/sceptre.cli.html
+++ b/2.2.0/apidoc/sceptre.cli.html
@@ -466,7 +466,7 @@ write <code class="docutils literal"><span class="pre">var</span></code> as a JS
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/sceptre.config.html
+++ b/2.2.0/apidoc/sceptre.config.html
@@ -461,7 +461,7 @@ attributes.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/sceptre.hooks.html
+++ b/2.2.0/apidoc/sceptre.hooks.html
@@ -402,7 +402,7 @@ groups within the current stack.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/sceptre.html
+++ b/2.2.0/apidoc/sceptre.html
@@ -1004,7 +1004,7 @@ the template itself.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/sceptre.plan.html
+++ b/2.2.0/apidoc/sceptre.plan.html
@@ -1121,7 +1121,7 @@ performed, launch exits gracefully.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/apidoc/sceptre.resolvers.html
+++ b/2.2.0/apidoc/sceptre.resolvers.html
@@ -480,7 +480,7 @@ current Sceptre stack_group’s account and region.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/architecture.html
+++ b/2.2.0/docs/architecture.html
@@ -356,7 +356,7 @@ to demonstrate ways of organising different projects.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/cli.html
+++ b/2.2.0/docs/cli.html
@@ -743,7 +743,7 @@ change-set when the change-set flag is set.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/faq.html
+++ b/2.2.0/docs/faq.html
@@ -305,7 +305,7 @@ used.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/get_started.html
+++ b/2.2.0/docs/get_started.html
@@ -410,7 +410,7 @@ reference to the CLI <a class="reference internal" href="cli.html"><span class="
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/hooks.html
+++ b/2.2.0/docs/hooks.html
@@ -414,7 +414,7 @@ In case you are not familiar with python packaging, <a class="reference external
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/install.html
+++ b/2.2.0/docs/install.html
@@ -268,7 +268,7 @@ documentation on how to achieve this.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/resolvers.html
+++ b/2.2.0/docs/resolvers.html
@@ -425,7 +425,7 @@ In case you are not familiar with python packaging, <a class="reference external
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/stack_config.html
+++ b/2.2.0/docs/stack_config.html
@@ -508,7 +508,7 @@ stack_tags:
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/stack_group_config.html
+++ b/2.2.0/docs/stack_group_config.html
@@ -454,7 +454,7 @@ template_bucket_name: {{ environment_variable.TEMPLATE_BUCKET_NAME }}
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/templates.html
+++ b/2.2.0/docs/templates.html
@@ -300,7 +300,7 @@ to generate CloudFormation Template as a <cite>json</cite> string.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/docs/terminology.html
+++ b/2.2.0/docs/terminology.html
@@ -324,7 +324,7 @@ the <code class="docutils literal"><span class="pre">Stack</span></code> when ca
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/genindex.html
+++ b/2.2.0/genindex.html
@@ -1221,7 +1221,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/index.html
+++ b/2.2.0/index.html
@@ -442,7 +442,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/py-modindex.html
+++ b/2.2.0/py-modindex.html
@@ -420,7 +420,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.0/search.html
+++ b/2.2.0/search.html
@@ -234,7 +234,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/index.html
+++ b/2.2.1/_modules/index.html
@@ -245,7 +245,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre.html
+++ b/2.2.1/_modules/sceptre.html
@@ -185,7 +185,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 <span class="n">__version__</span> <span class="o">=</span> <span class="s1">&#39;2.2.1&#39;</span>
 
 
@@ -244,7 +244,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/cli/helpers.html
+++ b/2.2.1/_modules/sceptre/cli/helpers.html
@@ -567,7 +567,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/config.html
+++ b/2.2.1/_modules/sceptre/config.html
@@ -186,7 +186,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -241,7 +241,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/config/graph.html
+++ b/2.2.1/_modules/sceptre/config/graph.html
@@ -330,7 +330,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/config/reader.html
+++ b/2.2.1/_modules/sceptre/config/reader.html
@@ -729,7 +729,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/config/strategies.html
+++ b/2.2.1/_modules/sceptre/config/strategies.html
@@ -298,7 +298,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/connection_manager.html
+++ b/2.2.1/_modules/sceptre/connection_manager.html
@@ -447,7 +447,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/context.html
+++ b/2.2.1/_modules/sceptre/context.html
@@ -344,7 +344,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/exceptions.html
+++ b/2.2.1/_modules/sceptre/exceptions.html
@@ -385,7 +385,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/helpers.html
+++ b/2.2.1/_modules/sceptre/helpers.html
@@ -334,7 +334,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/hooks.html
+++ b/2.2.1/_modules/sceptre/hooks.html
@@ -333,7 +333,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/hooks/asg_scaling_processes.html
+++ b/2.2.1/_modules/sceptre/hooks/asg_scaling_processes.html
@@ -315,7 +315,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/hooks/cmd.html
+++ b/2.2.1/_modules/sceptre/hooks/cmd.html
@@ -253,7 +253,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/plan.html
+++ b/2.2.1/_modules/sceptre/plan.html
@@ -186,7 +186,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -241,7 +241,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/plan/actions.html
+++ b/2.2.1/_modules/sceptre/plan/actions.html
@@ -1085,7 +1085,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/plan/executor.html
+++ b/2.2.1/_modules/sceptre/plan/executor.html
@@ -289,7 +289,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/plan/plan.html
+++ b/2.2.1/_modules/sceptre/plan/plan.html
@@ -582,7 +582,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/resolvers.html
+++ b/2.2.1/_modules/sceptre/resolvers.html
@@ -351,7 +351,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/resolvers/environment_variable.html
+++ b/2.2.1/_modules/sceptre/resolvers/environment_variable.html
@@ -255,7 +255,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/resolvers/file_contents.html
+++ b/2.2.1/_modules/sceptre/resolvers/file_contents.html
@@ -254,7 +254,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/resolvers/stack_output.html
+++ b/2.2.1/_modules/sceptre/resolvers/stack_output.html
@@ -395,7 +395,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/stack.html
+++ b/2.2.1/_modules/sceptre/stack.html
@@ -503,7 +503,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/stack_status.html
+++ b/2.2.1/_modules/sceptre/stack_status.html
@@ -251,7 +251,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/stack_status_colourer.html
+++ b/2.2.1/_modules/sceptre/stack_status_colourer.html
@@ -289,7 +289,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/_modules/sceptre/template.html
+++ b/2.2.1/_modules/sceptre/template.html
@@ -564,7 +564,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/about.html
+++ b/2.2.1/about.html
@@ -256,7 +256,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/modules.html
+++ b/2.2.1/apidoc/modules.html
@@ -302,7 +302,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/sceptre.cli.html
+++ b/2.2.1/apidoc/sceptre.cli.html
@@ -466,7 +466,7 @@ write <code class="docutils literal"><span class="pre">var</span></code> as a JS
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/sceptre.config.html
+++ b/2.2.1/apidoc/sceptre.config.html
@@ -461,7 +461,7 @@ attributes.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/sceptre.hooks.html
+++ b/2.2.1/apidoc/sceptre.hooks.html
@@ -402,7 +402,7 @@ groups within the current stack.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/sceptre.html
+++ b/2.2.1/apidoc/sceptre.html
@@ -1004,7 +1004,7 @@ the template itself.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/sceptre.plan.html
+++ b/2.2.1/apidoc/sceptre.plan.html
@@ -1121,7 +1121,7 @@ performed, launch exits gracefully.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/apidoc/sceptre.resolvers.html
+++ b/2.2.1/apidoc/sceptre.resolvers.html
@@ -480,7 +480,7 @@ current Sceptre stack_group’s account and region.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/architecture.html
+++ b/2.2.1/docs/architecture.html
@@ -356,7 +356,7 @@ to demonstrate ways of organising different projects.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/cli.html
+++ b/2.2.1/docs/cli.html
@@ -743,7 +743,7 @@ change-set when the change-set flag is set.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/faq.html
+++ b/2.2.1/docs/faq.html
@@ -305,7 +305,7 @@ used.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/get_started.html
+++ b/2.2.1/docs/get_started.html
@@ -410,7 +410,7 @@ reference to the CLI <a class="reference internal" href="cli.html"><span class="
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/hooks.html
+++ b/2.2.1/docs/hooks.html
@@ -414,7 +414,7 @@ In case you are not familiar with python packaging, <a class="reference external
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/install.html
+++ b/2.2.1/docs/install.html
@@ -268,7 +268,7 @@ documentation on how to achieve this.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/resolvers.html
+++ b/2.2.1/docs/resolvers.html
@@ -425,7 +425,7 @@ In case you are not familiar with python packaging, <a class="reference external
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/stack_config.html
+++ b/2.2.1/docs/stack_config.html
@@ -508,7 +508,7 @@ stack_tags:
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/stack_group_config.html
+++ b/2.2.1/docs/stack_group_config.html
@@ -454,7 +454,7 @@ template_bucket_name: {{ environment_variable.TEMPLATE_BUCKET_NAME }}
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/templates.html
+++ b/2.2.1/docs/templates.html
@@ -300,7 +300,7 @@ to generate CloudFormation Template as a <cite>json</cite> string.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/docs/terminology.html
+++ b/2.2.1/docs/terminology.html
@@ -324,7 +324,7 @@ the <code class="docutils literal"><span class="pre">Stack</span></code> when ca
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/genindex.html
+++ b/2.2.1/genindex.html
@@ -1221,7 +1221,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/index.html
+++ b/2.2.1/index.html
@@ -442,7 +442,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/py-modindex.html
+++ b/2.2.1/py-modindex.html
@@ -420,7 +420,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.2.1/search.html
+++ b/2.2.1/search.html
@@ -234,7 +234,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/index.html
+++ b/2.3.0/_modules/index.html
@@ -236,7 +236,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre.html
+++ b/2.3.0/_modules/sceptre.html
@@ -176,7 +176,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 <span class="n">__version__</span> <span class="o">=</span> <span class="s1">&#39;2.3.0&#39;</span>
 
 
@@ -235,7 +235,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/cli/helpers.html
+++ b/2.3.0/_modules/sceptre/cli/helpers.html
@@ -561,7 +561,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/config.html
+++ b/2.3.0/_modules/sceptre/config.html
@@ -177,7 +177,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -232,7 +232,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/config/graph.html
+++ b/2.3.0/_modules/sceptre/config/graph.html
@@ -321,7 +321,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/config/reader.html
+++ b/2.3.0/_modules/sceptre/config/reader.html
@@ -760,7 +760,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/config/strategies.html
+++ b/2.3.0/_modules/sceptre/config/strategies.html
@@ -289,7 +289,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/connection_manager.html
+++ b/2.3.0/_modules/sceptre/connection_manager.html
@@ -468,7 +468,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/context.html
+++ b/2.3.0/_modules/sceptre/context.html
@@ -335,7 +335,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/exceptions.html
+++ b/2.3.0/_modules/sceptre/exceptions.html
@@ -383,7 +383,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/helpers.html
+++ b/2.3.0/_modules/sceptre/helpers.html
@@ -325,7 +325,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/hooks.html
+++ b/2.3.0/_modules/sceptre/hooks.html
@@ -324,7 +324,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/hooks/asg_scaling_processes.html
+++ b/2.3.0/_modules/sceptre/hooks/asg_scaling_processes.html
@@ -306,7 +306,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/hooks/cmd.html
+++ b/2.3.0/_modules/sceptre/hooks/cmd.html
@@ -244,7 +244,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/plan.html
+++ b/2.3.0/_modules/sceptre/plan.html
@@ -177,7 +177,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -232,7 +232,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/plan/actions.html
+++ b/2.3.0/_modules/sceptre/plan/actions.html
@@ -1078,7 +1078,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/plan/executor.html
+++ b/2.3.0/_modules/sceptre/plan/executor.html
@@ -280,7 +280,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/plan/plan.html
+++ b/2.3.0/_modules/sceptre/plan/plan.html
@@ -573,7 +573,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/resolvers.html
+++ b/2.3.0/_modules/sceptre/resolvers.html
@@ -342,7 +342,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/resolvers/environment_variable.html
+++ b/2.3.0/_modules/sceptre/resolvers/environment_variable.html
@@ -246,7 +246,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/resolvers/file_contents.html
+++ b/2.3.0/_modules/sceptre/resolvers/file_contents.html
@@ -245,7 +245,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/resolvers/stack_output.html
+++ b/2.3.0/_modules/sceptre/resolvers/stack_output.html
@@ -391,7 +391,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/stack.html
+++ b/2.3.0/_modules/sceptre/stack.html
@@ -503,7 +503,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/stack_status.html
+++ b/2.3.0/_modules/sceptre/stack_status.html
@@ -242,7 +242,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/stack_status_colourer.html
+++ b/2.3.0/_modules/sceptre/stack_status_colourer.html
@@ -280,7 +280,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/_modules/sceptre/template.html
+++ b/2.3.0/_modules/sceptre/template.html
@@ -566,7 +566,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/about.html
+++ b/2.3.0/about.html
@@ -247,7 +247,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/modules.html
+++ b/2.3.0/apidoc/modules.html
@@ -293,7 +293,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/sceptre.cli.html
+++ b/2.3.0/apidoc/sceptre.cli.html
@@ -457,7 +457,7 @@ write <code class="docutils literal notranslate"><span class="pre">var</span></c
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/sceptre.config.html
+++ b/2.3.0/apidoc/sceptre.config.html
@@ -481,7 +481,7 @@ attributes.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/sceptre.hooks.html
+++ b/2.3.0/apidoc/sceptre.hooks.html
@@ -393,7 +393,7 @@ groups within the current stack.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/sceptre.html
+++ b/2.3.0/apidoc/sceptre.html
@@ -1007,7 +1007,7 @@ the template itself.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/sceptre.plan.html
+++ b/2.3.0/apidoc/sceptre.plan.html
@@ -1116,7 +1116,7 @@ performed, launch exits gracefully.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/apidoc/sceptre.resolvers.html
+++ b/2.3.0/apidoc/sceptre.resolvers.html
@@ -471,7 +471,7 @@ current Sceptre stack_group’s account and region.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/architecture.html
+++ b/2.3.0/docs/architecture.html
@@ -347,7 +347,7 @@ to demonstrate ways of organising different projects.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/cli.html
+++ b/2.3.0/docs/cli.html
@@ -776,7 +776,7 @@ change-set when the change-set flag is set.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/faq.html
+++ b/2.3.0/docs/faq.html
@@ -296,7 +296,7 @@ used.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/get_started.html
+++ b/2.3.0/docs/get_started.html
@@ -390,7 +390,7 @@ reference to the CLI <a class="reference internal" href="cli.html"><span class="
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/hooks.html
+++ b/2.3.0/docs/hooks.html
@@ -425,7 +425,7 @@ Assume a Sceptre <cite>copy</cite> hook that calls the <a class="reference exter
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/install.html
+++ b/2.3.0/docs/install.html
@@ -268,7 +268,7 @@ documentation on how to achieve this.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/resolvers.html
+++ b/2.3.0/docs/resolvers.html
@@ -429,7 +429,7 @@ In case you are not familiar with python packaging, <a class="reference external
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/stack_config.html
+++ b/2.3.0/docs/stack_config.html
@@ -498,7 +498,7 @@ the <code class="docutils literal notranslate"><span class="pre">sceptre_handler
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/stack_group_config.html
+++ b/2.3.0/docs/stack_group_config.html
@@ -444,7 +444,7 @@ invoking sceptre command:</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/templates.html
+++ b/2.3.0/docs/templates.html
@@ -291,7 +291,7 @@ to generate CloudFormation Template as a <cite>json</cite> string.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/docs/terminology.html
+++ b/2.3.0/docs/terminology.html
@@ -318,7 +318,7 @@ the <code class="docutils literal notranslate"><span class="pre">Stack</span></c
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/genindex.html
+++ b/2.3.0/genindex.html
@@ -1218,7 +1218,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/index.html
+++ b/2.3.0/index.html
@@ -438,7 +438,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/py-modindex.html
+++ b/2.3.0/py-modindex.html
@@ -411,7 +411,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/2.3.0/search.html
+++ b/2.3.0/search.html
@@ -225,7 +225,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-sceptre.cloudreach.com

--- a/dev/_modules/index.html
+++ b/dev/_modules/index.html
@@ -236,7 +236,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre.html
+++ b/dev/_modules/sceptre.html
@@ -176,7 +176,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 <span class="n">__version__</span> <span class="o">=</span> <span class="s1">&#39;2.3.0&#39;</span>
 
 
@@ -235,7 +235,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/cli/helpers.html
+++ b/dev/_modules/sceptre/cli/helpers.html
@@ -561,7 +561,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/config.html
+++ b/dev/_modules/sceptre/config.html
@@ -177,7 +177,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -232,7 +232,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/config/graph.html
+++ b/dev/_modules/sceptre/config/graph.html
@@ -321,7 +321,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/config/reader.html
+++ b/dev/_modules/sceptre/config/reader.html
@@ -762,7 +762,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/config/strategies.html
+++ b/dev/_modules/sceptre/config/strategies.html
@@ -289,7 +289,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/connection_manager.html
+++ b/dev/_modules/sceptre/connection_manager.html
@@ -468,7 +468,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/context.html
+++ b/dev/_modules/sceptre/context.html
@@ -335,7 +335,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/exceptions.html
+++ b/dev/_modules/sceptre/exceptions.html
@@ -383,7 +383,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/helpers.html
+++ b/dev/_modules/sceptre/helpers.html
@@ -325,7 +325,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/hooks.html
+++ b/dev/_modules/sceptre/hooks.html
@@ -324,7 +324,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/hooks/asg_scaling_processes.html
+++ b/dev/_modules/sceptre/hooks/asg_scaling_processes.html
@@ -306,7 +306,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/hooks/cmd.html
+++ b/dev/_modules/sceptre/hooks/cmd.html
@@ -244,7 +244,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/plan.html
+++ b/dev/_modules/sceptre/plan.html
@@ -177,7 +177,7 @@
 
 
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Cloudreach&#39;</span>
-<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre@cloudreach.com&#39;</span>
+<span class="n">__email__</span> <span class="o">=</span> <span class="s1">&#39;sceptre.github.io&#39;</span>
 
 
 <span class="c1"># Set up logging to ``/dev/null`` like a library is supposed to.</span>
@@ -232,7 +232,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/plan/actions.html
+++ b/dev/_modules/sceptre/plan/actions.html
@@ -1078,7 +1078,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/plan/executor.html
+++ b/dev/_modules/sceptre/plan/executor.html
@@ -280,7 +280,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/plan/plan.html
+++ b/dev/_modules/sceptre/plan/plan.html
@@ -573,7 +573,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/resolvers.html
+++ b/dev/_modules/sceptre/resolvers.html
@@ -342,7 +342,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/resolvers/environment_variable.html
+++ b/dev/_modules/sceptre/resolvers/environment_variable.html
@@ -246,7 +246,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/resolvers/file_contents.html
+++ b/dev/_modules/sceptre/resolvers/file_contents.html
@@ -245,7 +245,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/resolvers/stack_output.html
+++ b/dev/_modules/sceptre/resolvers/stack_output.html
@@ -391,7 +391,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/stack.html
+++ b/dev/_modules/sceptre/stack.html
@@ -503,7 +503,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/stack_status.html
+++ b/dev/_modules/sceptre/stack_status.html
@@ -242,7 +242,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/stack_status_colourer.html
+++ b/dev/_modules/sceptre/stack_status_colourer.html
@@ -280,7 +280,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/_modules/sceptre/template.html
+++ b/dev/_modules/sceptre/template.html
@@ -566,7 +566,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/about.html
+++ b/dev/about.html
@@ -247,7 +247,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/modules.html
+++ b/dev/apidoc/modules.html
@@ -293,7 +293,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/sceptre.cli.html
+++ b/dev/apidoc/sceptre.cli.html
@@ -457,7 +457,7 @@ write <code class="docutils literal notranslate"><span class="pre">var</span></c
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/sceptre.config.html
+++ b/dev/apidoc/sceptre.config.html
@@ -481,7 +481,7 @@ attributes.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/sceptre.hooks.html
+++ b/dev/apidoc/sceptre.hooks.html
@@ -393,7 +393,7 @@ groups within the current stack.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/sceptre.html
+++ b/dev/apidoc/sceptre.html
@@ -1007,7 +1007,7 @@ the template itself.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/sceptre.plan.html
+++ b/dev/apidoc/sceptre.plan.html
@@ -1116,7 +1116,7 @@ performed, launch exits gracefully.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/apidoc/sceptre.resolvers.html
+++ b/dev/apidoc/sceptre.resolvers.html
@@ -471,7 +471,7 @@ current Sceptre stack_group’s account and region.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/architecture.html
+++ b/dev/docs/architecture.html
@@ -347,7 +347,7 @@ to demonstrate ways of organising different projects.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/cli.html
+++ b/dev/docs/cli.html
@@ -776,7 +776,7 @@ change-set when the change-set flag is set.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/faq.html
+++ b/dev/docs/faq.html
@@ -296,7 +296,7 @@ used.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/get_started.html
+++ b/dev/docs/get_started.html
@@ -390,7 +390,7 @@ reference to the CLI <a class="reference internal" href="cli.html"><span class="
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/hooks.html
+++ b/dev/docs/hooks.html
@@ -425,7 +425,7 @@ Assume a Sceptre <cite>copy</cite> hook that calls the <a class="reference exter
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/install.html
+++ b/dev/docs/install.html
@@ -268,7 +268,7 @@ documentation on how to achieve this.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/resolvers.html
+++ b/dev/docs/resolvers.html
@@ -429,7 +429,7 @@ In case you are not familiar with python packaging, <a class="reference external
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/stack_config.html
+++ b/dev/docs/stack_config.html
@@ -498,7 +498,7 @@ the <code class="docutils literal notranslate"><span class="pre">sceptre_handler
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/stack_group_config.html
+++ b/dev/docs/stack_group_config.html
@@ -444,7 +444,7 @@ invoking sceptre command:</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/templates.html
+++ b/dev/docs/templates.html
@@ -397,7 +397,7 @@ to generate CloudFormation Template as a <cite>json</cite> string.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/docs/terminology.html
+++ b/dev/docs/terminology.html
@@ -318,7 +318,7 @@ the <code class="docutils literal notranslate"><span class="pre">Stack</span></c
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/genindex.html
+++ b/dev/genindex.html
@@ -1218,7 +1218,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -441,7 +441,7 @@ information about Sceptre below.</p>
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/py-modindex.html
+++ b/dev/py-modindex.html
@@ -411,7 +411,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 

--- a/dev/search.html
+++ b/dev/search.html
@@ -225,7 +225,7 @@
                 
 
                     <dd>
-                        <a href="https://www.sceptre.cloudreach.com">Sceptre Home</a>
+                        <a href="https://sceptre.github.io">Sceptre Home</a>
                     </dd>
                 
 


### PR DESCRIPTION
This will change the domain for Sceptre docs back to the default of
`sceptre.github.io`, rather than `sceptre.cloudreach.com`.