### PR TITLE
Change domain for sceptre docs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-sceptre.cloudreach.com
+docs.sceptre-project.org


### PR DESCRIPTION
This is to partially resolve [issue #1098](https://github.com/Sceptre/sceptre/issues/1098)

We plan to move sceptre docs away from hosting on a
[cloudreach domain](https://sceptre.cloudreach.com/2.6.3/) to
the independent `sceptre-project.org` domain 